### PR TITLE
Fix false positive rate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "byteorder",
  "clap",
  "hex",
+ "rand_aes",
  "reqwest",
  "tokio",
 ]
@@ -1208,6 +1209,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_aes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2a5761d4b040674107330783e395c27d881d173eba8c34274c7f79372b85f2"
+dependencies = [
+ "getrandom 0.3.4",
  "rand_core",
 ]
 

--- a/downloader/Cargo.toml
+++ b/downloader/Cargo.toml
@@ -10,4 +10,5 @@ tokio = { version = "1", features = ["full"]}
 clap = { version = "4", features = ["derive"] }
 byteorder = "1"
 hex = "0.4"
+rand_aes = "0.6"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "gzip", "brotli", "deflate"] }

--- a/downloader/src/sink/bloom.rs
+++ b/downloader/src/sink/bloom.rs
@@ -3,12 +3,21 @@ use crate::DownloadConfig;
 use ::tokio::sync::mpsc::{Receiver, Sender};
 use anyhow::anyhow;
 use bloomfilter::Bloom;
+use rand_aes::{Aes256Ctr128, Random};
+use std::thread::yield_now;
+use std::time::Instant;
 use tokio::io::AsyncWriteExt;
 use tokio::task::JoinHandle;
+
+const BLOOM_CAPACITY: usize = 2_100_000_000;
+const BLOOM_TARGET_FALSE_POSITIVE_RATE: f64 = 0.001; // 0.1%
+const VERIFY_ITERATIONS: u64 = 10_000_000;
+const VERIFY_PROGRESS_INTERVAL: u64 = 1_000_000;
 
 pub struct SinkBloom {
     config: DownloadConfig,
     recv: Receiver<SinkMsg>,
+    bloom_entries: usize,
 }
 
 impl SinkBloom {
@@ -16,10 +25,14 @@ impl SinkBloom {
         let (sender, recv) = ::tokio::sync::mpsc::channel(50_000);
 
         let jh = ::tokio::spawn(async move {
-            (Self { recv, config })
-                .run()
-                .await
-                .expect("stdout sink crashed.");
+            (Self {
+                recv,
+                config,
+                bloom_entries: 0,
+            })
+            .run()
+            .await
+            .expect("stdout sink crashed.");
         });
 
         (jh, sender)
@@ -27,14 +40,15 @@ impl SinkBloom {
 
     pub async fn run(&mut self) -> Result<(), ()> {
         let mut bloom: Bloom<[u8]> =
-            Bloom::new_for_fp_rate(1_010_000_000, 0.01).expect("could not create bloom filter");
+            Bloom::new_for_fp_rate(BLOOM_CAPACITY, BLOOM_TARGET_FALSE_POSITIVE_RATE)
+                .expect("could not create bloom filter");
 
         loop {
             match self.recv.recv().await {
                 None => continue,
                 Some(s) => match s {
                     SinkMsg::Finish => {
-                        self.finish(&mut bloom)
+                        self.finish(bloom)
                             .await
                             .expect("could not write bloom file");
                         return Ok(());
@@ -48,20 +62,22 @@ impl SinkBloom {
         }
     }
 
-    pub async fn finish(&self, bloom: &mut Bloom<[u8]>) -> Result<(), ::anyhow::Error> {
+    pub async fn finish(&self, bloom: Bloom<[u8]>) -> Result<(), ::anyhow::Error> {
         eprintln!("start writing bloom filter.");
 
-        let bloom_file = self
+        let bloom_file_path = self
             .config
             .opt
             .sink_bloom_file
             .as_ref()
             .expect("must be given");
 
-        let mut bloomfile = ::tokio::fs::File::create(bloom_file).await?;
-        bloomfile.write_all(bloom.as_slice()).await?;
+        let mut bloom_data_file = ::tokio::fs::File::create(bloom_file_path).await?;
+        bloom_data_file.write_all(bloom.as_slice()).await?;
 
         eprintln!("finished writing bloom filter.");
+
+        self.verify(bloom).await?;
 
         Ok(())
     }
@@ -94,8 +110,70 @@ impl SinkBloom {
             };
 
             bloom.set(hash.as_bytes());
+            self.bloom_entries += 1;
         }
 
         Ok(())
+    }
+
+    async fn verify(&self, bloom: Bloom<[u8]>) -> Result<(), ::anyhow::Error> {
+        eprintln!("starting false positive rate verification ({VERIFY_ITERATIONS} iterations)...");
+
+        let rng = Aes256Ctr128::from_entropy();
+        let mut buf = [0u8; 512];
+        let mut false_positives: u64 = 0;
+
+        let start = Instant::now();
+
+        for i in 1..=VERIFY_ITERATIONS {
+            rng.fill_bytes(&mut buf[..]);
+
+            if bloom.check(&buf) {
+                false_positives += 1;
+            }
+
+            if i.is_multiple_of(VERIFY_PROGRESS_INTERVAL) {
+                let rate = false_positives as f64 / i as f64;
+                eprintln!(
+                    "  [{}/{}] false positives: {}, observed rate: {:.6}",
+                    i, VERIFY_ITERATIONS, false_positives, rate
+                );
+                yield_now()
+            }
+        }
+
+        let elapsed = start.elapsed();
+        let observed_rate = false_positives as f64 / VERIFY_ITERATIONS as f64;
+
+        eprintln!();
+        eprintln!("=== Verification Results ===");
+        eprintln!("Iterations:         {}", VERIFY_ITERATIONS);
+        eprintln!("False positives:    {}", false_positives);
+        eprintln!("Observed FP rate:   {:.6}", observed_rate);
+        eprintln!(
+            "Expected FP rate:   {:.6}",
+            BLOOM_TARGET_FALSE_POSITIVE_RATE
+        );
+        eprintln!(
+            "Ratio (obs/exp):    {:.3}",
+            observed_rate / BLOOM_TARGET_FALSE_POSITIVE_RATE
+        );
+        eprintln!("Test duration:      {:.2?}", elapsed);
+        eprintln!(
+            "Checks per second:  {:.0}",
+            VERIFY_ITERATIONS as f64 / elapsed.as_secs_f64()
+        );
+
+        if self.bloom_entries > BLOOM_CAPACITY {
+            eprintln!("WARNING: Bloom filter entries ({}) exceeded capacity of bloom filter. Increase the {BLOOM_CAPACITY}", self.bloom_entries);
+        }
+
+        if observed_rate <= BLOOM_TARGET_FALSE_POSITIVE_RATE * 1.1 {
+            eprintln!("PASS: Observed false positive rate is within 10% of expected.");
+            Ok(())
+        } else {
+            eprintln!("FAIL: Observed false positive rate exceeds 10% of the expected value.");
+            Err(anyhow!("elevated false positive rate"))
+        }
     }
 }

--- a/downloader/src/sink/bloom.rs
+++ b/downloader/src/sink/bloom.rs
@@ -1,12 +1,13 @@
 use crate::sink::SinkMsg;
 use crate::DownloadConfig;
-use ::tokio::sync::mpsc::{Receiver, Sender};
+use std::thread::yield_now;
+use std::time::Instant;
+
 use anyhow::anyhow;
 use bloomfilter::Bloom;
 use rand_aes::{Aes256Ctr128, Random};
-use std::thread::yield_now;
-use std::time::Instant;
 use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::task::JoinHandle;
 
 const BLOOM_CAPACITY: usize = 2_100_000_000;


### PR DESCRIPTION
Also added a verification at the end of the download.

```
=== Verification Results ===
Iterations:         10000000
False positives:    8575
Observed FP rate:   0.000857
Expected FP rate:   0.001000
Ratio (obs/exp):    0.857
Test duration:      4.02s
Checks per second:  2489866
PASS: Observed false positive rate is within 10% of expected
```

False positive rate was before this change 6%!